### PR TITLE
Add username_searcher entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ A curated list of tools and sites for **username search**, **account discovery**
 - [sagemode](https://github.com/senran101604/sagemode) — Simple username search.
   - 146 sites; real-time CLI output; known false positives on some platforms 🚫; no longer maintained (last commit Dec 2023) 🚫.
 
+- [username_searcher](https://github.com/qwerasdzx-123/username_searcher) — Browser-based username checker with a local Node.js proxy; bilingual Chinese/English UI.
+  - 104 sites (999 in the bundled database, but only the "common" tier is queried); local web UI with live progress 👍; username permutation generator 👍; JSON/CSV export 👍; validation rules for only 3 sites, the rest rely on status/title/length heuristics — many results land in "manual verify" 🚫; upstream proxy hardcoded to a LAN address 🚫; `node js/proxy-server.js` + `node js/simple-server.js`.
+
 - [Arina-OSINT](https://github.com/AlexC-ux/Arina-OSINT) — Username search written in C#.
   - 76 sites; requires .NET Core 3.1; no longer maintained (last commit Mar 2022) 🚫.
 


### PR DESCRIPTION
Closes #23.

Adds [username_searcher](https://github.com/qwerasdzx-123/username_searcher) to **Open source tools**, placed by site count between sagemode (146) and Arina-OSINT (76).

It's a browser-based cross-site username checker: a local Node.js static server + HTTP CONNECT proxy, with a bilingual (zh/en) web UI.

Notes behind the pros/cons in the entry:
- The bundled `data/社交网站及用户页面.json` has 999 entries, but `js/app.js` loads only `common_sites` — 104 sites are actually queried.
- `data/sites-db.json` contains validation rules for just 3 domains (archive.org, github.com, reddit.com); the rest rely on status code / title / content-length heuristics, which produces a lot of "manual verify" results.
- `js/proxy-server.js` hardcodes `PROXY_HOST = '192.168.1.29'` / `PROXY_PORT = 7897`, so it needs editing (or switching the UI to direct mode) before it works elsewhere.