### PR TITLE
Remove dead Namecheckr entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ These tools focus on **username availability** and brand/domain squatting checks
 
 - [Namechk](https://namechk.com/) — Availability across 96 sites and 36 TLDs.
 
-- [Namecheckr](https://www.namecheckr.com/) — Domains and social handles across 38 networks and 17 TLDs.
-
 - [Checkerapi](https://app.swaggerhub.com/apis/checker/api) — Six services; [open source](https://github.com/checker/api) 👍.
 
 - [360username](https://360username.com/) — AI-powered Domain name and sicial media username generator and checker.


### PR DESCRIPTION
`https://www.namecheckr.com/` is down — it returns HTTP 503 with the site's own
branded "Error 503 - Service Unavailable" page, consistently across retries.
That's the origin failing, not a Cloudflare bot challenge, so the entry is
removed rather than annotated.