### PR TITLE
Add Namevine and IntelX username tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ These tools focus on **username availability** and brand/domain squatting checks
 
 - [Namechk](https://namechk.com/) — Availability across 96 sites and 36 TLDs.
 
+- [Namevine](https://namevine.com/) — Search one name across domains and social handles; free, optional account.
+
 - [Checkerapi](https://app.swaggerhub.com/apis/checker/api) — Six services; [open source](https://github.com/checker/api) 👍.
 
 - [360username](https://360username.com/) — AI-powered Domain name and sicial media username generator and checker.
@@ -147,6 +149,8 @@ These tools focus on **username availability** and brand/domain squatting checks
 - [One-plus OSINT Toolkit](https://one-plus.github.io/EmailUsername) — Email/username-oriented OSINT toolkit.
 
 - [Aware-online username search](https://www.aware-online.com/en/osint-tools/username-search-tool/) — Browser-based username search tool.
+
+- [Intelligence X username tools](https://intelx.io/tools?tab=username) — Username tab of the IntelX tool directory; links out to third-party username search services.
 
 ## Useful links
 


### PR DESCRIPTION
Picked these up while going through the username sections of the popular
start.me OSINT catalogs (OSINT4ALL, Nixintel, OSINT-US and a few more).

Namevine goes to Branding, since it checks domains next to social handles.
The IntelX tools page goes to Toolkits — it's a link directory, not a
checker of its own.

Most of what those catalogs list is already here, and a good chunk of the
rest is dead, so this is the whole harvest.
